### PR TITLE
feat(bin): add audio and video pid options

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -2,17 +2,37 @@
 
 const generateID3Segment = require('../');
 
-// Turn the first argument into a id3 tag
-if (process.argv[2]) {
+const args = process.argv.slice(2);
+
+let videoPidIndex = args.indexOf('-v')
+
+if (videoPidIndex === -1) {
+  videoPidIndex = args.indexOf('--video-pid');
+}
+const videoPid = videoPidIndex !== -1 ? args.splice(videoPidIndex, 2)[1] || null : null;
+
+let audioPidIndex = args.indexOf('-a');
+
+if (audioPidIndex === -1) {
+  audioPidIndex = args.indexOf('--audio-pid');
+}
+const audioPid = audioPidIndex !== -1 ? args.splice(audioPidIndex, 2)[1] || null : null;
+
+const data = args.pop();
+
+if (data) {
   const options = {
     pmtPid: 0x100,
     id3Pid: 0x103,
-    videoPid: null,
-    audioPid: null,
     id3PTS: 282743,
-    data: process.argv[2],
+    videoPid,
+    audioPid,
+    data
   };
+
   generateID3Segment(options).then((segment) => {
     process.stdout.write(segment);
   });
+} else {
+  console.error('Please add some data');
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,13 +18,20 @@ if (audioPidIndex === -1) {
 }
 const audioPid = audioPidIndex !== -1 ? args.splice(audioPidIndex, 2)[1] || null : null;
 
+let id3PtsIndex = args.indexOf('-p');
+
+if (id3PtsIndex === -1) {
+  id3PtsIndex = args.indexOf('--id3-pts');
+}
+const id3PTS = id3PtsIndex !== -1 ? Number(args.splice(id3PtsIndex, 2)[1]) || 282743 : 282743;
+
 const data = args.pop();
 
 if (data) {
   const options = {
     pmtPid: 0x100,
     id3Pid: 0x103,
-    id3PTS: 282743,
+    id3PTS,
     videoPid,
     audioPid,
     data


### PR DESCRIPTION
Add a new -v/-a or --video-pid/--audio-pid option to the binary.
This allows us to more easily create a ts segment for testing with a
particular pid.