### PR TITLE
Bugfix: Use ID3 length in bytes to compute PES packet length

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const writeID3TagChunked = (outputBuffer, destinationStart, data, id3Pid, contin
 const generateID3Packets = (outputBuffer, destination, options) => {
   const { data, id3Pid, id3PTS } = options;
 
-  const id3Length = calculateId3TagLength(data.length);
+  const id3Length = calculateId3TagLength(Buffer.byteLength(data));
   const pesPacketLength = id3Length + sizeOf.PES_HEADER + sizeOf.PTS;
   const paddingNeeded = Math.ceil(pesPacketLength / MAX_TS_PAYLOAD) * MAX_TS_PAYLOAD - pesPacketLength;
 
@@ -199,7 +199,7 @@ const generateID3Packets = (outputBuffer, destination, options) => {
  * @returns {Buffer}
  */
 const generateSegment = (options) => {
-  const outputLength = calculateOutputBufferLength(options.data.length);
+  const outputLength = calculateOutputBufferLength(Buffer.byteLength(options.data));
   const outputBuffer = Buffer.allocUnsafe(outputLength);
 
   generatePATPacket(outputBuffer, 0, options);

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -30,14 +30,15 @@ describe('./index', () => {
     verifyPmt(secondPacket, options.pmtPid, options.id3Pid);
 
     // Verify the last packet - the PES
+    const dataBuffer = Buffer.from(options.data);
     const lastPacket = b.slice(376);
     const pesHeader = lastPacket.slice(4);
-    const id3TagLength = 10 + 12 + options.data.length + 1;
+    const id3TagLength = 10 + 12 + dataBuffer.length + 1;
     const paddingLength = 184 - (id3TagLength + 14);
     const id3StartByte = 4 + 14 + paddingLength;
 
     verifyPesHeader(pesHeader, options.id3PTS, id3TagLength, paddingLength);
-    veryifyId3(lastPacket.slice(id3StartByte), options.data);
+    veryifyId3(lastPacket.slice(id3StartByte), dataBuffer);
   });
 
   it('should generate a single-TS segment asynchronously', () => {
@@ -60,14 +61,15 @@ describe('./index', () => {
       verifyPmt(secondPacket, options.pmtPid, options.id3Pid);
 
       // Verify the last packet - the PES
+      const dataBuffer = Buffer.from(options.data);
       const lastPacket = b.slice(376);
       const pesHeader = lastPacket.slice(4);
-      const id3TagLength = 10 + 12 + options.data.length + 1;
+      const id3TagLength = 10 + 12 + dataBuffer.length + 1;
       const paddingLength = 184 - (id3TagLength + 14);
       const id3StartByte = 4 + 14 + paddingLength;
 
       verifyPesHeader(pesHeader, options.id3PTS, id3TagLength, paddingLength);
-      veryifyId3(lastPacket.slice(id3StartByte), options.data);
+      veryifyId3(lastPacket.slice(id3StartByte), dataBuffer);
     });
   });
 
@@ -91,9 +93,10 @@ describe('./index', () => {
     verifyPmt(secondPacket, options.pmtPid, options.id3Pid);
 
     // Verify the third packet - the PES
+    const dataBuffer = Buffer.from(options.data);
     const thirdPacket = b.slice(376);
     const pesHeader = thirdPacket.slice(4);
-    const id3TagLength = 10 + 12 + options.data.length + 1;
+    const id3TagLength = 10 + 12 + dataBuffer.length + 1;
     const paddingLength = 368 - (id3TagLength + 14);
     const id3StartByte = 376 + 4 + 14 + paddingLength;
 
@@ -105,7 +108,7 @@ describe('./index', () => {
       b.slice(id3StartByte, 564),
       b.slice(568),
     ]);
-    veryifyId3(id3Tag, options.data);
+    veryifyId3(id3Tag, dataBuffer);
 
     // Verify the last packet - the PES (cont.)
     const lastPacket = b.slice(564);
@@ -132,9 +135,10 @@ describe('./index', () => {
     verifyPmt(secondPacket, options.pmtPid, options.id3Pid);
 
     // Verify the third packet - the PES
+    const dataBuffer = Buffer.from(options.data);
     const thirdPacket = b.slice(376);
     const pesHeader = thirdPacket.slice(4);
-    const id3TagLength = 10 + 12 + options.data.length + 1;
+    const id3TagLength = 10 + 12 + dataBuffer.length + 1;
     const paddingLength = 368 - (id3TagLength + 14);
     const id3StartByte = 4 + 14 + paddingLength + 4;
 
@@ -142,7 +146,7 @@ describe('./index', () => {
     verifyPesHeader(pesHeader, options.id3PTS, id3TagLength, paddingLength);
      // console.log(thirdPacket.slice(id3StartByte).toString('hex').replace(/(\w\w)/g, '0x$1, '));
 
-    veryifyId3(thirdPacket.slice(id3StartByte), options.data);
+    veryifyId3(thirdPacket.slice(id3StartByte), dataBuffer);
 
     // Verify the last packet - the PES (cont.)
     const lastPacket = b.slice(564);

--- a/test/utils.js
+++ b/test/utils.js
@@ -160,7 +160,7 @@ const verifyFrameHeader = (b, frameLength) => {
 };
 
 const verifyPayload = (b, expectedPayload) => {
-  assert.equal(b.toString('utf8'), expectedPayload);
+  assert.deepStrictEqual(b, expectedPayload);
 }
 
 exports.veryifyId3 = (b, expectedPayload) => {


### PR DESCRIPTION
PES packet lengths are currently computed using the ID3 data character length, which breaks when the data contains multi-byte UTF-8 characters. This change fixes the header length computation to use the byte length.